### PR TITLE
Implement session-based login

### DIFF
--- a/app/Http/Controllers/SessionController.php
+++ b/app/Http/Controllers/SessionController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class SessionController extends Controller
+{
+    /**
+     * Show login form
+     */
+    public function create()
+    {
+        return view('auth.login');
+    }
+
+    /**
+     * Handle login request using session authentication
+     */
+    public function store(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        $remember = $request->boolean('remember');
+
+        if (Auth::attempt($credentials, $remember)) {
+            $request->session()->regenerate();
+
+            $user = $request->user();
+            if ($user instanceof User) {
+                if (!$user->isActive()) {
+                    Auth::logout();
+                    return back()->withErrors([
+                        'email' => 'Konto jest nieaktywne lub zablokowane.',
+                    ]);
+                }
+
+                $user->updateLoginInfo($request->ip());
+
+                // Redirect based on role
+                return redirect()->intended(match(true) {
+                    $user->isAdmin() => route('admin.dashboard'),
+                    $user->isModerator() => route('moderator.dashboard'),
+                    $user->isTutor() => route('tutor.dashboard'),
+                    $user->isStudent() => route('student.dashboard'),
+                    default => '/'
+                });
+            }
+
+            return redirect('/');
+        }
+
+        return back()->withErrors([
+            'email' => 'Podane dane logowania są nieprawidłowe.',
+        ])->onlyInput('email');
+    }
+
+    /**
+     * Logout the user
+     */
+    public function destroy(Request $request)
+    {
+        Auth::logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect('/');
+    }
+}

--- a/resources/ts/main.ts
+++ b/resources/ts/main.ts
@@ -371,13 +371,10 @@ class TutoringApp {
     }
   }
 
-  private async handleLogoutClick(): Promise<void> {
-    try {
-      await authService.logout();
-    } catch (error) {
-      console.error('Logout error:', error);
-      // Force logout on client side even if API fails
-      authService.logout();
+  private handleLogoutClick(): void {
+    const form = document.getElementById('logout-form') as HTMLFormElement | null;
+    if (form) {
+      form.submit();
     }
   }
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -13,7 +13,17 @@
                     <p>Wprowadź swoje dane, aby uzyskać dostęp do konta</p>
                 </div>
 
-                <form id="login-form" class="auth-form">
+                <form id="login-form" class="auth-form" method="POST" action="{{ route('login.post') }}">
+                    @csrf
+                    @if($errors->any())
+                        <div class="alert alert-danger">
+                            <ul>
+                                @foreach ($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
                     <div class="form-group">
                         <label for="email">Email</label>
                         <input type="email" id="email" name="email" class="form-control" required>
@@ -181,11 +191,7 @@
 }
 </style>
 
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    new LoginForm('#login-form');
-});
-</script>
+
 @endsection
 
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -230,6 +230,10 @@
         <i class="fas fa-chevron-up"></i>
     </button>
 
+    <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+        @csrf
+    </form>
+
     <style>
         /* Auth Buttons Styles - nowe style dla przycisków autentykacji */
         .auth-buttons {

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\SessionController;
 
 // Homepage - publiczny
 Route::get('/', function () {
@@ -16,9 +17,8 @@ Route::get('/health', function () {
 
 // Authentication pages (tylko dla gości)
 Route::middleware('guest')->group(function () {
-    Route::get('/login', function () {
-        return view('auth.login');
-    })->name('login');
+    Route::get('/login', [SessionController::class, 'create'])->name('login');
+    Route::post('/login', [SessionController::class, 'store'])->name('login.post');
 
     Route::get('/register', function () {
         return view('auth.register');
@@ -33,8 +33,10 @@ Route::middleware('guest')->group(function () {
     })->name('password.reset');
 });
 
+Route::post('/logout', [SessionController::class, 'destroy'])->middleware('auth')->name('logout');
+
 // Dashboard routes (wymagają autentykacji i weryfikacji email)
-Route::middleware(['auth:sanctum', 'verified'])->group(function () {
+Route::middleware(['auth', 'verified'])->group(function () {
 
     // Admin dashboard
     Route::middleware('role:admin')->group(function () {


### PR DESCRIPTION
## Summary
- add SessionController for session-driven login
- switch dashboard routes to `auth` middleware
- handle login with HTML form and show validation errors
- add hidden logout form and update JS logout

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848341aeff88328afc99bcc9c2c640d