### PR TITLE
Use Laravel password reset table

### DIFF
--- a/app/Http/Requests/NewPasswordRequest.php
+++ b/app/Http/Requests/NewPasswordRequest.php
@@ -15,6 +15,7 @@ class NewPasswordRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'email' => 'required|email|exists:users,email',
             'token' => 'required|string',
             'password' => 'required|string|min:8|confirmed'
         ];
@@ -23,6 +24,9 @@ class NewPasswordRequest extends FormRequest
     public function messages(): array
     {
         return [
+            'email.required' => 'Email jest wymagany',
+            'email.email' => 'Email musi być poprawny',
+            'email.exists' => 'Nie znaleziono konta z tym adresem email',
             'token.required' => 'Token resetowania jest wymagany',
             'password.required' => 'Nowe hasło jest wymagane',
             'password.min' => 'Hasło musi mieć minimum 8 znaków',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Password;
 
 class User extends Authenticatable
 {
@@ -30,8 +31,6 @@ class User extends Authenticatable
         'last_login_at',
         'last_login_ip',
         'verification_token',
-        'password_reset_token',
-        'password_reset_expires_at',
         'email_verified_at'
     ];
 
@@ -40,7 +39,6 @@ class User extends Authenticatable
         'remember_token',
         'two_factor_secret',
         'two_factor_recovery_codes',
-        'password_reset_token',
         'verification_token'
     ];
 
@@ -48,7 +46,6 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'birth_date' => 'date',
         'last_login_at' => 'datetime',
-        'password_reset_expires_at' => 'datetime',
         'is_verified' => 'boolean',
         'two_factor_recovery_codes' => 'array'
     ];
@@ -186,14 +183,7 @@ class User extends Authenticatable
     // Authentication helper methods
     public function generatePasswordResetToken(): string
     {
-        $token = bin2hex(random_bytes(32));
-
-        $this->update([
-            'password_reset_token' => $token,
-            'password_reset_expires_at' => Carbon::now()->addHours(24)
-        ]);
-
-        return $token;
+        return Password::createToken($this);
     }
 
     public function generateVerificationToken(): string

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -52,7 +52,7 @@ class NotificationService
     public function sendPasswordResetEmail(User $user, string $token): void
     {
         try {
-            $resetUrl = url("/reset-password?token={$token}");
+            $resetUrl = url("/reset-password?token={$token}&email={$user->email}");
 
             Log::info("Password reset email should be sent to: {$user->email}");
             Log::info("Reset URL: {$resetUrl}");

--- a/resources/ts/components/auth/ResetPasswordForm.ts
+++ b/resources/ts/components/auth/ResetPasswordForm.ts
@@ -111,6 +111,7 @@ export class ResetPasswordForm {
 
         const formData = new FormData(this.form)
         const data = {
+            email: formData.get('email') as string,
             token: formData.get('token') as string,
             password: formData.get('password') as string,
             password_confirmation: formData.get('password_confirmation') as string
@@ -284,12 +285,17 @@ export class ResetPasswordForm {
         if (!this.form) return
 
         const tokenField = this.form.querySelector('[name="token"]') as HTMLInputElement
+        const emailField = this.form.querySelector('[name="email"]') as HTMLInputElement
         const tokenValue = tokenField?.value
+        const emailValue = emailField?.value
 
         this.form.reset()
 
         if (tokenField && tokenValue) {
             tokenField.value = tokenValue
+        }
+        if (emailField && emailValue) {
+            emailField.value = emailValue
         }
 
         this.validator.clearErrors()

--- a/resources/ts/types/auth.ts
+++ b/resources/ts/types/auth.ts
@@ -22,6 +22,7 @@ export interface PasswordResetData {
 }
 
 export interface NewPasswordData {
+    email: string
     token: string
     password: string
     password_confirmation: string

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -15,6 +15,7 @@
 
                 <form id="reset-password-form" class="auth-form">
                     <input type="hidden" name="token" value="{{ request('token') }}">
+                    <input type="hidden" name="email" value="{{ request('email') }}">
 
                     <div class="form-group">
                         <label for="password">Nowe hasło</label>


### PR DESCRIPTION
## Summary
- switch to Laravel's `password_resets` table for handling reset tokens
- adjust reset password validation and email link
- update front-end reset password form and types

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_684839d7416c8328b4e035176f3fc04a