### PR TITLE
Add legacy styles to SPA

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,18 +1,28 @@
-/* Import Bootstrap and components */
+/* ------------------------------------------------------------------
+   Base Imports
+   ------------------------------------------------------------------ */
 
+/* Bootstrap core */
 @import 'bootstrap/dist/css/bootstrap.min.css';
 
-/* NEW STYLES */
+/* Shared variables and utilities used by all styles */
+@import './components/variables.css';
+@import './components/animations.css';
+@import './components/utilities.css';
+@import './components/responsive.css';
+@import './components/base.css';
+@import './components/notifications.css';
+
+/* Legacy front‑end components (homepage sections, footer, etc.) */
+@import './components/header.css';
+@import './components/hero.css';
+@import './components/features.css';
+@import './components/about.css';
+@import './components/lecturers.css';
+@import './components/footer.css';
+
+/* New SPA specific styles */
 @import './components/layout.css';
 @import './components/auth.css';
 @import './components/dashboard.css';
-
-
-/* OLD STYLES */
-@import './components/variables.css';
-@import "./components/base.css";
-@import './components/notifications.css';
-@import './components/utilities.css';
-@import './components/animations.css';
-@import './components/responsive.css';
 

--- a/resources/css/components/about.css
+++ b/resources/css/components/about.css
@@ -1,0 +1,139 @@
+/* About Section */
+.about {
+    padding: var(--space-3xl) 0;
+    background: var(--bg-secondary);
+    position: relative;
+}
+
+.about::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="aboutPattern" width="50" height="50" patternUnits="userSpaceOnUse"><circle cx="25" cy="25" r="2" fill="rgb(233, 30, 99)" opacity="0.03"/></pattern></defs><rect width="100%" height="100%" fill="url(%23aboutPattern)"/></svg>');
+}
+
+.about .container {
+    position: relative;
+    z-index: 2;
+}
+
+.about h2 {
+    font-size: clamp(1.8rem, 3.5vw, 2.25rem);
+    margin-bottom: var(--space-md);
+    color: var(--text-primary);
+    font-weight: var(--font-bold);
+    position: relative;
+}
+
+.about h2::after {
+    content: '';
+    position: absolute;
+    bottom: -10px;
+    left: 0;
+    width: 60px;
+    height: 3px;
+    background: var(--primary-gradient);
+    border-radius: var(--radius-sm);
+}
+
+.about h3 {
+    font-size: var(--font-size-xl);
+    margin-bottom: var(--space-md);
+    color: var(--text-primary);
+    font-weight: var(--font-semibold);
+    margin-top: var(--space-xl);
+}
+
+.about p {
+    color: var(--text-secondary);
+    line-height: var(--leading-relaxed);
+    margin-bottom: var(--space-md);
+    font-size: var(--font-size-base);
+}
+
+/* Contact Info */
+.contact-info {
+    margin-bottom: var(--space-xl);
+}
+
+.contact-info p {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-sm);
+    padding: var(--space-sm);
+    background: var(--bg-primary);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    transition: var(--transition);
+}
+
+.contact-info p:hover {
+    transform: translateX(5px);
+    box-shadow: var(--shadow);
+}
+
+.contact-info i {
+    color: var(--primary-pink);
+    font-size: var(--font-size-lg);
+    width: 20px;
+    text-align: center;
+}
+
+/* Languages List */
+.languages-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    margin-top: var(--space-md);
+}
+
+.language-tag {
+    background: var(--primary-gradient);
+    color: var(--text-white);
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-medium);
+    transition: var(--transition);
+    position: relative;
+    overflow: hidden;
+}
+
+.language-tag::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+    transition: left 0.5s ease;
+}
+
+.language-tag:hover::before {
+    left: 100%;
+}
+
+.language-tag:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow);
+}
+
+/* Animation for about section content */
+.about .row > div {
+    opacity: 0;
+    transform: translateY(30px);
+    animation: fadeInUp 0.8s ease forwards;
+}
+
+.about .row > div:first-child {
+    animation-delay: 0.2s;
+}
+
+.about .row > div:last-child {
+    animation-delay: 0.4s;
+}

--- a/resources/css/components/features.css
+++ b/resources/css/components/features.css
@@ -1,0 +1,147 @@
+/* Features Section */
+.features {
+    padding: var(--space-3xl) 0;
+    background: var(--bg-secondary);
+    position: relative;
+}
+
+.features::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 100px;
+    background: linear-gradient(180deg, var(--primary-pink) 0%, var(--bg-secondary) 100%);
+    opacity: 0.05;
+}
+
+.features .section-title {
+    text-align: center;
+    font-size: clamp(2rem, 4vw, 2.5rem);
+    margin-bottom: var(--space-2xl);
+    color: var(--text-primary);
+    font-weight: var(--font-bold);
+}
+
+.features-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    gap: var(--space-xl);
+    margin-top: var(--space-2xl);
+}
+
+.feature-card {
+    background: var(--bg-primary);
+    padding: var(--space-xl);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow);
+    text-align: center;
+    transition: var(--transition);
+    position: relative;
+    overflow: hidden;
+    border: 1px solid transparent;
+}
+
+.feature-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 4px;
+    background: var(--primary-gradient);
+    transition: left 0.5s ease;
+}
+
+.feature-card:hover::before {
+    left: 0;
+}
+
+.feature-card:hover {
+    transform: translateY(-10px);
+    box-shadow: var(--shadow-xl);
+    border-color: rgba(233, 30, 99, 0.1);
+}
+
+.feature-icon {
+    width: 80px;
+    height: 80px;
+    background: var(--primary-gradient);
+    border-radius: var(--radius-full);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto var(--space-md);
+    font-size: var(--font-size-2xl);
+    color: var(--text-white);
+    transition: var(--transition);
+    position: relative;
+    overflow: hidden;
+}
+
+.feature-icon::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.3) 0%, transparent 70%);
+}
+
+.feature-card:hover .feature-icon {
+    transform: rotate(360deg) scale(1.1);
+    box-shadow: var(--shadow-lg);
+}
+
+.feature-card h3 {
+    font-size: var(--font-size-xl);
+    margin-bottom: var(--space-md);
+    color: var(--text-primary);
+    font-weight: var(--font-semibold);
+}
+
+.feature-card p {
+    color: var(--text-secondary);
+    line-height: var(--leading-relaxed);
+    margin-bottom: 0;
+}
+
+/* Feature card animations */
+.feature-card {
+    opacity: 0;
+    transform: translateY(50px);
+    animation: fadeInUp 0.6s ease forwards;
+}
+
+.feature-card:nth-child(1) { animation-delay: 0.1s; }
+.feature-card:nth-child(2) { animation-delay: 0.2s; }
+.feature-card:nth-child(3) { animation-delay: 0.3s; }
+.feature-card:nth-child(4) { animation-delay: 0.4s; }
+.feature-card:nth-child(5) { animation-delay: 0.5s; }
+.feature-card:nth-child(6) { animation-delay: 0.6s; }
+
+@keyframes fadeInUp {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Enhanced hover effects */
+.feature-card::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: radial-gradient(circle at center, rgba(233, 30, 99, 0.05) 0%, transparent 70%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.feature-card:hover::after {
+    opacity: 1;
+}

--- a/resources/css/components/footer.css
+++ b/resources/css/components/footer.css
@@ -1,0 +1,211 @@
+/* Footer */
+.footer {
+    background: var(--bg-dark);
+    color: var(--text-white);
+    padding: var(--space-3xl) 0 var(--space-lg);
+    position: relative;
+    overflow: hidden;
+}
+
+.footer::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="footerPattern" width="40" height="40" patternUnits="userSpaceOnUse"><circle cx="20" cy="20" r="1" fill="white" opacity="0.05"/><circle cx="5" cy="5" r="0.5" fill="white" opacity="0.03"/></pattern></defs><rect width="100%" height="100%" fill="url(%23footerPattern)"/></svg>');
+}
+
+.footer-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: var(--space-xl);
+    margin-bottom: var(--space-xl);
+    position: relative;
+    z-index: 2;
+}
+
+.footer-section {
+    position: relative;
+}
+
+.footer-section h3 {
+    margin-bottom: var(--space-md);
+    background: var(--primary-gradient);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    font-weight: var(--font-semibold);
+    font-size: var(--font-size-lg);
+    position: relative;
+}
+
+.footer-section h3::after {
+    content: '';
+    position: absolute;
+    bottom: -8px;
+    left: 0;
+    width: 40px;
+    height: 2px;
+    background: var(--primary-gradient);
+    border-radius: var(--radius-sm);
+}
+
+.footer-section p {
+    color: var(--text-light);
+    line-height: var(--leading-relaxed);
+    margin-bottom: var(--space-sm);
+    font-size: var(--font-size-sm);
+}
+
+.footer-section p i {
+    color: var(--primary-pink);
+    margin-right: var(--space-xs);
+    width: 16px;
+    text-align: center;
+}
+
+/* Social Links */
+.social-links {
+    display: flex;
+    gap: var(--space-sm);
+    margin-top: var(--space-md);
+}
+
+.social-links a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    background: var(--primary-gradient);
+    color: var(--text-white);
+    border-radius: var(--radius-full);
+    text-decoration: none;
+    transition: var(--transition);
+    font-size: var(--font-size-lg);
+}
+
+.social-links a:hover {
+    transform: translateY(-3px) scale(1.1);
+    box-shadow: var(--shadow-lg);
+}
+
+/* Footer Links */
+.footer-links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.footer-links li {
+    margin-bottom: var(--space-xs);
+}
+
+.footer-links a {
+    color: var(--text-light);
+    text-decoration: none;
+    transition: var(--transition);
+    font-size: var(--font-size-sm);
+    display: inline-block;
+    position: relative;
+}
+
+.footer-links a:hover {
+    color: var(--text-white);
+    padding-left: var(--space-xs);
+    transform: translateX(5px);
+}
+
+.footer-links a::before {
+    content: '';
+    position: absolute;
+    left: -10px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 0;
+    height: 2px;
+    background: var(--primary-gradient);
+    transition: width 0.3s ease;
+}
+
+.footer-links a:hover::before {
+    width: 6px;
+}
+
+/* Languages Footer */
+.languages-footer {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.languages-footer li {
+    color: var(--text-light);
+    margin-bottom: var(--space-xs);
+    font-size: var(--font-size-sm);
+    position: relative;
+    padding-left: var(--space-md);
+    transition: var(--transition);
+}
+
+.languages-footer li::before {
+    content: '•';
+    position: absolute;
+    left: 0;
+    color: var(--primary-pink);
+    font-weight: bold;
+}
+
+.languages-footer li:hover {
+    color: var(--text-white);
+    padding-left: var(--space-lg);
+}
+
+/* Footer Bottom */
+.footer-bottom {
+    border-top: 1px solid #334155;
+    padding-top: var(--space-lg);
+    text-align: center;
+    color: var(--text-light);
+    position: relative;
+    z-index: 2;
+}
+
+.footer-bottom p {
+    margin: 0;
+    font-size: var(--font-size-sm);
+}
+
+/* Back to Top Button */
+.back-to-top {
+    position: fixed;
+    bottom: var(--space-lg);
+    right: var(--space-lg);
+    width: 50px;
+    height: 50px;
+    background: var(--primary-gradient);
+    color: var(--text-white);
+    border: none;
+    border-radius: var(--radius-full);
+    cursor: pointer;
+    font-size: var(--font-size-lg);
+    box-shadow: var(--shadow-lg);
+    transition: var(--transition);
+    z-index: var(--z-fixed);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(100px);
+}
+
+.back-to-top.visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.back-to-top:hover {
+    transform: translateY(-5px);
+    box-shadow: var(--shadow-xl);
+}

--- a/resources/css/components/header.css
+++ b/resources/css/components/header.css
@@ -1,0 +1,207 @@
+/* Header & Navigation */
+.header {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    box-shadow: var(--shadow);
+    position: fixed;
+    width: 100%;
+    top: 0;
+    z-index: var(--z-fixed);
+    transition: var(--transition);
+}
+
+.header.scrolled {
+    background: rgba(255, 255, 255, 0.98);
+    box-shadow: var(--shadow-md);
+}
+
+.nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-sm) 0;
+    min-height: 70px;
+}
+
+/* Logo */
+.logo {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-bold);
+    color: var(--text-primary);
+}
+
+.logo i {
+    background: var(--primary-gradient);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    font-size: var(--font-size-2xl);
+}
+
+.logo a {
+    background: var(--primary-gradient);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-decoration: none;
+}
+
+.logo a:hover {
+    background: var(--primary-gradient-hover);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+/* Navigation Links */
+.nav-links {
+    display: flex;
+    list-style: none;
+    gap: var(--space-lg);
+    align-items: center;
+    margin: 0;
+}
+
+.nav-links a {
+    text-decoration: none;
+    color: var(--text-primary);
+    font-weight: var(--font-medium);
+    transition: var(--transition);
+    position: relative;
+    padding: var(--space-xs) 0;
+}
+
+.nav-links a:hover {
+    color: var(--primary-pink);
+}
+
+.nav-links a::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 0;
+    height: 2px;
+    background: var(--primary-gradient);
+    transition: width 0.3s ease;
+}
+
+.nav-links a:hover::after {
+    width: 100%;
+}
+
+/* Navigation Actions */
+.nav-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+}
+
+.login-btn {
+    background: var(--primary-gradient);
+    color: var(--text-white);
+    padding: var(--space-xs) var(--space-md);
+    border-radius: var(--radius);
+    text-decoration: none;
+    font-weight: var(--font-semibold);
+    transition: var(--transition);
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+}
+
+.login-btn:hover {
+    background: var(--primary-gradient-hover);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+    color: var(--text-white);
+}
+
+/* Mobile Menu Button */
+.mobile-menu-btn {
+    display: none;
+    background: none;
+    border: none;
+    font-size: var(--font-size-xl);
+    color: var(--text-primary);
+    cursor: pointer;
+    padding: var(--space-xs);
+    transition: var(--transition);
+}
+
+.mobile-menu-btn:hover {
+    color: var(--primary-pink);
+    transform: scale(1.1);
+}
+
+/* Mobile Menu */
+.mobile-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: var(--bg-primary);
+    box-shadow: var(--shadow-lg);
+    border-top: 1px solid #e2e8f0;
+    z-index: var(--z-dropdown);
+}
+
+.mobile-menu.active {
+    display: block;
+    animation: slideDown 0.3s ease;
+}
+
+.mobile-nav-links {
+    list-style: none;
+    padding: var(--space-md);
+    margin: 0;
+}
+
+.mobile-nav-links li {
+    margin-bottom: var(--space-sm);
+}
+
+.mobile-nav-links a {
+    display: block;
+    padding: var(--space-md);
+    color: var(--text-primary);
+    text-decoration: none;
+    font-weight: var(--font-medium);
+    border-radius: var(--radius);
+    transition: var(--transition);
+}
+
+.mobile-nav-links a:hover {
+    background: var(--bg-secondary);
+    color: var(--primary-pink);
+}
+
+.mobile-login-btn {
+    background: var(--primary-gradient) !important;
+    color: var(--text-white) !important;
+    text-align: center;
+    margin-top: var(--space-md);
+}
+
+.mobile-login-btn:hover {
+    background: var(--primary-gradient-hover) !important;
+    color: var(--text-white) !important;
+}
+
+/* Animation for mobile menu */
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/resources/css/components/hero.css
+++ b/resources/css/components/hero.css
@@ -1,0 +1,164 @@
+/* Hero Section */
+.hero {
+    background: var(--primary-gradient);
+    color: var(--text-white);
+    padding: 140px 0 100px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+}
+
+.hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="25" cy="25" r="1" fill="white" opacity="0.1"/><circle cx="75" cy="75" r="1" fill="white" opacity="0.1"/><circle cx="50" cy="10" r="0.5" fill="white" opacity="0.1"/><circle cx="10" cy="50" r="0.8" fill="white" opacity="0.08"/><circle cx="90" cy="30" r="0.6" fill="white" opacity="0.08"/></pattern></defs><rect width="100%" height="100%" fill="url(%23grain)"/></svg>');
+    animation: float 20s ease-in-out infinite;
+}
+
+.hero::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 70% 80%, rgba(255, 255, 255, 0.08) 0%, transparent 50%);
+}
+
+@keyframes float {
+    0%, 100% {
+        transform: translateY(0px) rotate(0deg);
+    }
+    50% {
+        transform: translateY(-20px) rotate(1deg);
+    }
+}
+
+.hero-content {
+    position: relative;
+    z-index: 2;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.hero-title {
+    font-size: clamp(2.5rem, 5vw, 4rem);
+    margin-bottom: var(--space-md);
+    font-weight: var(--font-bold);
+    line-height: var(--leading-tight);
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.hero-subtitle {
+    font-size: clamp(1.1rem, 2.5vw, 1.25rem);
+    margin-bottom: var(--space-xl);
+    opacity: 0.95;
+    line-height: var(--leading-relaxed);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.cta-buttons {
+    display: flex;
+    gap: var(--space-md);
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-top: var(--space-xl);
+}
+
+.cta-buttons .btn {
+    padding: 15px 30px;
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-semibold);
+    border-radius: var(--radius-md);
+    transition: var(--transition);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    text-decoration: none;
+    min-width: 200px;
+    justify-content: center;
+}
+
+.hero .btn-primary {
+    background: var(--bg-primary);
+    color: var(--primary-pink);
+    box-shadow: var(--shadow-lg);
+}
+
+.hero .btn-primary:hover {
+    background: var(--bg-secondary);
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-xl);
+    color: var(--primary-pink-hover);
+}
+
+.hero .btn-secondary {
+    background: transparent;
+    color: var(--text-white);
+    border: 2px solid var(--text-white);
+}
+
+.hero .btn-secondary:hover {
+    background: var(--text-white);
+    color: var(--primary-pink);
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-xl);
+}
+
+/* Hero animations */
+.hero-content > * {
+    opacity: 0;
+    transform: translateY(30px);
+    animation: heroFadeIn 0.8s ease forwards;
+}
+
+.hero-title {
+    animation-delay: 0.2s;
+}
+
+.hero-subtitle {
+    animation-delay: 0.4s;
+}
+
+.cta-buttons {
+    animation-delay: 0.6s;
+}
+
+@keyframes heroFadeIn {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Scroll indicator */
+.hero::after {
+    content: '';
+    position: absolute;
+    bottom: 30px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 2px;
+    height: 30px;
+    background: rgba(255, 255, 255, 0.5);
+    animation: scrollIndicator 2s ease-in-out infinite;
+}
+
+@keyframes scrollIndicator {
+    0%, 100% {
+        opacity: 0.5;
+        transform: translateX(-50%) translateY(0);
+    }
+    50% {
+        opacity: 1;
+        transform: translateX(-50%) translateY(10px);
+    }
+}

--- a/resources/css/components/lecturers.css
+++ b/resources/css/components/lecturers.css
@@ -1,0 +1,185 @@
+/* Lecturers Section */
+.lecturers {
+    padding: var(--space-3xl) 0;
+    background: var(--bg-primary);
+}
+
+.lecturers .section-title {
+    text-align: center;
+    font-size: clamp(2rem, 4vw, 2.5rem);
+    margin-bottom: var(--space-2xl);
+    color: var(--text-primary);
+    font-weight: var(--font-bold);
+}
+
+.lecturers-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: var(--space-xl);
+    margin-bottom: var(--space-xl);
+}
+
+.lecturer-card {
+    background: var(--bg-primary);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+    transition: var(--transition);
+    border: 1px solid #e2e8f0;
+}
+
+.lecturer-card:hover {
+    transform: translateY(-8px);
+    box-shadow: var(--shadow-xl);
+    border-color: rgba(233, 30, 99, 0.2);
+}
+
+.lecturer-avatar {
+    width: 100%;
+    height: 250px;
+    background: var(--primary-gradient);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 4rem;
+    color: var(--text-white);
+    position: relative;
+    overflow: hidden;
+}
+
+.lecturer-avatar::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.2) 0%, transparent 50%),
+    radial-gradient(circle at 70% 80%, rgba(255, 255, 255, 0.1) 0%, transparent 50%);
+}
+
+.lecturer-avatar i {
+    position: relative;
+    z-index: 2;
+    transition: var(--transition);
+}
+
+.lecturer-card:hover .lecturer-avatar i {
+    transform: scale(1.1);
+}
+
+.lecturer-info {
+    padding: var(--space-xl);
+}
+
+.lecturer-name {
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-semibold);
+    margin-bottom: var(--space-xs);
+    color: var(--text-primary);
+}
+
+.lecturer-languages {
+    color: var(--primary-pink);
+    margin-bottom: var(--space-md);
+    font-weight: var(--font-medium);
+    font-size: var(--font-size-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.lecturer-rating {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-md);
+}
+
+.stars {
+    color: #fbbf24;
+    font-size: var(--font-size-sm);
+    display: flex;
+    gap: 2px;
+}
+
+.rating-text {
+    color: var(--text-light);
+    font-size: var(--font-size-sm);
+    margin-left: var(--space-xs);
+}
+
+.lecturer-description {
+    color: var(--text-secondary);
+    line-height: var(--leading-relaxed);
+    margin-bottom: 0;
+    font-size: var(--font-size-sm);
+}
+
+/* Login Note */
+.login-note {
+    background: linear-gradient(135deg, #fef3c7, #fde68a);
+    padding: var(--space-md);
+    border-radius: var(--radius-lg);
+    text-align: center;
+    border-left: 4px solid var(--primary-orange);
+    margin-top: var(--space-xl);
+    position: relative;
+    overflow: hidden;
+}
+
+.login-note::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="dots" width="20" height="20" patternUnits="userSpaceOnUse"><circle cx="10" cy="10" r="1" fill="rgb(251, 191, 36)" opacity="0.1"/></pattern></defs><rect width="100%" height="100%" fill="url(%23dots)"/></svg>');
+}
+
+.login-note i {
+    color: var(--primary-orange);
+    margin-right: var(--space-xs);
+    font-size: var(--font-size-lg);
+}
+
+.login-note strong {
+    color: var(--primary-pink);
+    font-weight: var(--font-semibold);
+}
+
+.login-note p {
+    margin: 0;
+    position: relative;
+    z-index: 2;
+    color: var(--text-primary);
+}
+
+/* Lecturer card animations */
+.lecturer-card {
+    opacity: 0;
+    transform: translateY(50px);
+    animation: fadeInUp 0.6s ease forwards;
+}
+
+.lecturer-card:nth-child(1) { animation-delay: 0.1s; }
+.lecturer-card:nth-child(2) { animation-delay: 0.2s; }
+.lecturer-card:nth-child(3) { animation-delay: 0.3s; }
+
+/* Hover effects for lecturer cards */
+.lecturer-card::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(135deg, rgba(233, 30, 99, 0.02) 0%, rgba(255, 107, 53, 0.02) 100%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+}
+
+.lecturer-card:hover::after {
+    opacity: 1;
+}


### PR DESCRIPTION
## Summary
- import shared, legacy, and SPA styles in a single place
- restore classic CSS components (header, hero, features, lecturers, etc.) so the new SPA looks like the earlier version

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing vite/client types)*

------
https://chatgpt.com/codex/tasks/task_e_684ff5adb1b88328b5923703aca19226