### PR TITLE
Fix loading button visuals and identify unused components

### DIFF
--- a/resources/css/components/base.css
+++ b/resources/css/components/base.css
@@ -127,6 +127,22 @@ a:hover {
     border: none;
 }
 
+/* Loading state for buttons */
+.btn-loading {
+    pointer-events: none;
+    opacity: 0.8;
+}
+
+.btn-loading .btn-text {
+    opacity: 0;
+}
+
+.btn-loading .btn-loading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+}
+
 .btn-gradient:hover {
     background: var(--primary-gradient-hover);
     transform: translateY(-2px);

--- a/resources/ts/components/auth/EmailVerificationPage.ts
+++ b/resources/ts/components/auth/EmailVerificationPage.ts
@@ -533,6 +533,7 @@ export class EmailVerificationPage implements RouteComponent {
         const btnLoading = button.querySelector('.btn-loading')
 
         button.disabled = loading
+        button.classList.toggle('btn-loading', loading)
 
         if (btnText && btnLoading) {
             btnText.classList.toggle('hidden', loading)

--- a/resources/ts/components/auth/ForgotPasswordPage.ts
+++ b/resources/ts/components/auth/ForgotPasswordPage.ts
@@ -311,6 +311,7 @@ export class ForgotPasswordPage implements RouteComponent {
 
         if (submitBtn && btnText && btnLoading) {
             submitBtn.disabled = loading
+            submitBtn.classList.toggle('btn-loading', loading)
             btnText.classList.toggle('hidden', loading)
             btnLoading.classList.toggle('hidden', !loading)
         }

--- a/resources/ts/components/auth/LoginPage.ts
+++ b/resources/ts/components/auth/LoginPage.ts
@@ -325,6 +325,7 @@ export class LoginPage implements RouteComponent {
 
         if (submitBtn && btnText && btnLoading) {
             submitBtn.disabled = loading
+            submitBtn.classList.toggle('btn-loading', loading)
             btnText.classList.toggle('hidden', loading)
             btnLoading.classList.toggle('hidden', !loading)
         }

--- a/resources/ts/components/auth/RegisterPage.ts
+++ b/resources/ts/components/auth/RegisterPage.ts
@@ -530,6 +530,7 @@ export class RegisterPage implements RouteComponent {
 
         if (submitBtn && btnText && btnLoading) {
             submitBtn.disabled = loading
+            submitBtn.classList.toggle('btn-loading', loading)
             btnText.classList.toggle('hidden', loading)
             btnLoading.classList.toggle('hidden', !loading)
         }

--- a/resources/ts/components/auth/ResetPasswordPage.ts
+++ b/resources/ts/components/auth/ResetPasswordPage.ts
@@ -444,6 +444,7 @@ export class ResetPasswordPage implements RouteComponent {
 
         if (submitBtn && btnText && btnLoading) {
             submitBtn.disabled = loading
+            submitBtn.classList.toggle('btn-loading', loading)
             btnText.classList.toggle('hidden', loading)
             btnLoading.classList.toggle('hidden', !loading)
         }

--- a/resources/ts/components/common/Footer.ts
+++ b/resources/ts/components/common/Footer.ts
@@ -311,6 +311,7 @@ export class Footer implements RouteComponent {
         }
 
         // Show loading state
+        submitBtn.classList.add('btn-loading')
         btnText.classList.add('hidden')
         btnLoading.classList.remove('hidden')
         submitBtn.disabled = true
@@ -326,6 +327,7 @@ export class Footer implements RouteComponent {
             this.showNewsletterMessage('Wystąpił błąd. Spróbuj ponownie później.', 'error')
         } finally {
             // Reset button state
+            submitBtn.classList.remove('btn-loading')
             btnText.classList.remove('hidden')
             btnLoading.classList.add('hidden')
             submitBtn.disabled = false


### PR DESCRIPTION
## Summary
- add `.btn-loading` state styles for buttons
- toggle `btn-loading` class in auth forms and newsletter form
- highlight unused components `LoadingPage` and `LoadingSpinner`

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68500df0efe88328a4f6dd1bf501e333