### PR TITLE
Implement SPA frontend pages

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,18 @@
 /* Bootstrap core */
 @import 'bootstrap/dist/css/bootstrap.min.css';
 
+/* Component styles */
+@import './components/navigation.css';
+@import './components/footer.css';
 
-
+/* Page styles */
+@import './pages/home.css';
+@import './pages/login.css';
+@import './pages/register.css';
+@import './pages/forgot-password.css';
+@import './pages/reset-password.css';
+@import './pages/email-verification.css';
+@import './pages/admin-dashboard.css';
+@import './pages/student-dashboard.css';
+@import './pages/not-found.css';
+@import './pages/unauthorized.css';

--- a/resources/css/components/footer.css
+++ b/resources/css/components/footer.css
@@ -1,0 +1,33 @@
+footer {
+    background: #1e293b;
+    color: #fff;
+    padding: 60px 0 20px;
+}
+footer .footer-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 2rem;
+    margin-bottom: 2rem;
+    padding: 0 20px;
+}
+footer .footer-section h3 {
+    margin-bottom: 1rem;
+    color: #e91e63;
+}
+footer .footer-section p,
+footer .footer-section a {
+    color: #94a3b8;
+    text-decoration: none;
+    line-height: 1.8;
+}
+footer .footer-section a:hover {
+    color: #fff;
+}
+footer .footer-bottom {
+    border-top: 1px solid #334155;
+    text-align: center;
+    color: #94a3b8;
+    padding-top: 20px;
+}

--- a/resources/css/components/navigation.css
+++ b/resources/css/components/navigation.css
@@ -1,0 +1,51 @@
+header {
+    background: #fff;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    position: fixed;
+    width: 100%;
+    top: 0;
+    z-index: 1000;
+}
+nav.navbar {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1rem 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.navbar .logo {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #e91e63;
+}
+.navbar .nav-links {
+    display: flex;
+    list-style: none;
+    gap: 2rem;
+}
+.navbar .nav-links a {
+    text-decoration: none;
+    color: #333;
+    font-weight: 500;
+    transition: color 0.3s;
+}
+.navbar .nav-links a:hover {
+    color: #e91e63;
+}
+.navbar .login-btn {
+    background: #e91e63;
+    color: #fff;
+    padding: 0.5rem 1.5rem;
+    border-radius: 5px;
+    text-decoration: none;
+    transition: background 0.3s;
+}
+.navbar .login-btn:hover {
+    background: #c2185b;
+}
+@media (max-width: 768px) {
+    .navbar .nav-links {
+        display: none;
+    }
+}

--- a/resources/css/pages/admin-dashboard.css
+++ b/resources/css/pages/admin-dashboard.css
@@ -1,0 +1,3 @@
+.admin-dashboard {
+    padding: 2rem;
+}

--- a/resources/css/pages/email-verification.css
+++ b/resources/css/pages/email-verification.css
@@ -1,0 +1,1 @@
+@import './login.css';

--- a/resources/css/pages/forgot-password.css
+++ b/resources/css/pages/forgot-password.css
@@ -1,0 +1,1 @@
+@import './login.css';

--- a/resources/css/pages/home.css
+++ b/resources/css/pages/home.css
@@ -1,0 +1,158 @@
+.hero {
+    background: linear-gradient(135deg, #ff6b35 0%, #e91e63 100%);
+    color: #fff;
+    padding: 120px 0 80px;
+    text-align: center;
+}
+.hero h1 {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+    font-weight: 700;
+}
+.hero p {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.9;
+}
+.cta-buttons {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+.btn {
+    padding: 12px 30px;
+    border-radius: 5px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: all 0.3s;
+    display: inline-block;
+}
+.btn-primary {
+    background: #fff;
+    color: #2563eb;
+}
+.btn-primary:hover {
+    background: #f8fafc;
+    transform: translateY(-2px);
+}
+.btn-secondary {
+    background: transparent;
+    color: #fff;
+    border: 2px solid #fff;
+}
+.btn-secondary:hover {
+    background: #fff;
+    color: #2563eb;
+}
+.features {
+    padding: 80px 0;
+    background: #f8fafc;
+}
+.features h2 {
+    text-align: center;
+    font-size: 2.5rem;
+    margin-bottom: 3rem;
+    color: #1e293b;
+}
+.features-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+}
+.feature-card {
+    background: #fff;
+    padding: 2rem;
+    border-radius: 10px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    text-align: center;
+    transition: transform 0.3s;
+}
+.feature-card:hover {
+    transform: translateY(-5px);
+}
+.feature-icon {
+    width: 60px;
+    height: 60px;
+    background: #e91e63;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 1rem;
+    font-size: 24px;
+    color: #fff;
+}
+.lecturers {
+    padding: 80px 0;
+}
+.lecturers h2 {
+    text-align: center;
+    font-size: 2.5rem;
+    margin-bottom: 3rem;
+    color: #1e293b;
+}
+.lecturers-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+}
+.lecturer-card {
+    background: #fff;
+    border-radius: 10px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    overflow: hidden;
+    transition: transform 0.3s;
+}
+.lecturer-card:hover {
+    transform: translateY(-5px);
+}
+.lecturer-avatar {
+    width: 100%;
+    height: 200px;
+    background: linear-gradient(45deg, #ff6b35, #e91e63);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 48px;
+    color: #fff;
+}
+.lecturer-info {
+    padding: 1.5rem;
+}
+.lecturer-name {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: #1e293b;
+}
+.lecturer-languages {
+    color: #2563eb;
+    margin-bottom: 1rem;
+}
+.lecturer-rating {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+.stars {
+    color: #fbbf24;
+}
+.login-note {
+    background: #fef3c7;
+    padding: 1rem;
+    border-radius: 5px;
+    text-align: center;
+    color: #92400e;
+    font-size: 0.9rem;
+}
+@media (max-width: 768px) {
+    .hero h1 {
+        font-size: 2rem;
+    }
+    .cta-buttons {
+        flex-direction: column;
+        align-items: center;
+    }
+}

--- a/resources/css/pages/login.css
+++ b/resources/css/pages/login.css
@@ -1,0 +1,131 @@
+body.login-page {
+    background: linear-gradient(135deg, #ff6b35 0%, #e91e63 100%);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+}
+.login-container {
+    background: #fff;
+    border-radius: 15px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+    overflow: hidden;
+    width: 100%;
+    max-width: 900px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    min-height: 500px;
+}
+.login-form-section {
+    padding: 3rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+.login-info-section {
+    background: linear-gradient(135deg, #e91e63 0%, #c2185b 100%);
+    color: #fff;
+    padding: 3rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+}
+.login-logo {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #e91e63;
+    margin-bottom: 1rem;
+}
+.form-title {
+    font-size: 2rem;
+    font-weight: 600;
+    color: #1e293b;
+    margin-bottom: 0.5rem;
+}
+.form-subtitle {
+    color: #64748b;
+    margin-bottom: 2rem;
+}
+.form-group {
+    margin-bottom: 1.5rem;
+}
+.form-group label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    color: #374151;
+}
+.form-control {
+    width: 100%;
+    padding: 12px 16px;
+    border: 2px solid #e5e7eb;
+    border-radius: 8px;
+    font-size: 16px;
+    transition: border-color 0.3s, box-shadow 0.3s;
+}
+.form-control:focus {
+    outline: none;
+    border-color: #e91e63;
+    box-shadow: 0 0 0 3px rgba(233, 30, 99, 0.1);
+}
+.form-control.error {
+    border-color: #ef4444;
+}
+.error-message {
+    color: #ef4444;
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+    display: none;
+}
+.form-options {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2rem;
+}
+.login-btn {
+    width: 100%;
+    background: #2563eb;
+    color: #fff;
+    padding: 12px;
+    border: none;
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.3s, transform 0.1s;
+}
+.login-btn:hover {
+    background: #1d4ed8;
+}
+.login-btn:disabled {
+    background: #94a3b8;
+    cursor: not-allowed;
+}
+.loading-spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #ffffff;
+    border-top: 2px solid transparent;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    display: none;
+}
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+@media (max-width: 768px) {
+    .login-container {
+        grid-template-columns: 1fr;
+        max-width: 400px;
+    }
+    .login-info-section {
+        display: none;
+    }
+    .login-form-section {
+        padding: 2rem;
+    }
+}

--- a/resources/css/pages/not-found.css
+++ b/resources/css/pages/not-found.css
@@ -1,0 +1,4 @@
+.not-found {
+    padding: 4rem 2rem;
+    text-align: center;
+}

--- a/resources/css/pages/register.css
+++ b/resources/css/pages/register.css
@@ -1,0 +1,1 @@
+@import './login.css';

--- a/resources/css/pages/reset-password.css
+++ b/resources/css/pages/reset-password.css
@@ -1,0 +1,1 @@
+@import './login.css';

--- a/resources/css/pages/student-dashboard.css
+++ b/resources/css/pages/student-dashboard.css
@@ -1,0 +1,3 @@
+.student-dashboard {
+    padding: 2rem;
+}

--- a/resources/css/pages/unauthorized.css
+++ b/resources/css/pages/unauthorized.css
@@ -1,0 +1,4 @@
+.unauthorized {
+    padding: 4rem 2rem;
+    text-align: center;
+}

--- a/resources/ts/components/auth/EmailVerificationPage.ts
+++ b/resources/ts/components/auth/EmailVerificationPage.ts
@@ -1,0 +1,39 @@
+import { authService } from '@services/AuthService'
+import type { RouteComponent } from '@router/routes'
+
+export class EmailVerificationPage implements RouteComponent {
+    async render(): Promise<HTMLElement> {
+        const container = document.createElement('div')
+        document.body.classList.add('login-page')
+        container.innerHTML = `
+            <div class="login-container">
+                <div class="login-form-section">
+                    <div class="login-logo">Platforma Lektorów</div>
+                    <h1 class="form-title">Weryfikacja e-mail</h1>
+                    <p>Sprawdź swoją skrzynkę pocztową i kliknij w link weryfikacyjny.</p>
+                    <button class="login-btn" id="resendBtn">Wyślij ponownie</button>
+                </div>
+                <div class="login-info-section">
+                    <div>
+                        <h2>Dziękujemy za rejestrację!</h2>
+                        <p>Potwierdź swój adres e-mail, aby korzystać z platformy.</p>
+                    </div>
+                </div>
+            </div>`
+        return container
+    }
+
+    mount(container: HTMLElement): void {
+        const params = new URLSearchParams(window.location.search)
+        const token = params.get('token')
+        if (token) {
+            authService.verifyEmail(token).catch(err => alert(err.message))
+        }
+        const resendBtn = container.querySelector('#resendBtn') as HTMLButtonElement
+        resendBtn.addEventListener('click', () => authService.resendVerification())
+    }
+
+    unmount(): void {
+        document.body.classList.remove('login-page')
+    }
+}

--- a/resources/ts/components/auth/ForgotPasswordPage.ts
+++ b/resources/ts/components/auth/ForgotPasswordPage.ts
@@ -1,0 +1,59 @@
+import { authService } from '@services/AuthService'
+import type { RouteComponent } from '@router/routes'
+
+export class ForgotPasswordPage implements RouteComponent {
+    private form: HTMLFormElement | null = null
+
+    async render(): Promise<HTMLElement> {
+        const container = document.createElement('div')
+        document.body.classList.add('login-page')
+        container.innerHTML = `
+            <div class="login-container">
+                <div class="login-form-section">
+                    <div class="login-logo">Platforma Lektorów</div>
+                    <h1 class="form-title">Resetuj hasło</h1>
+                    <form id="forgotForm">
+                        <div class="form-group">
+                            <label for="email">Adres e-mail</label>
+                            <input type="email" id="email" name="email" class="form-control" required>
+                        </div>
+                        <button type="submit" class="login-btn" id="forgotButton">Wyślij link</button>
+                    </form>
+                </div>
+                <div class="login-info-section">
+                    <div>
+                        <h2>Zapomniałeś hasła?</h2>
+                        <p>Podaj swój adres e-mail, a wyślemy link do resetu.</p>
+                    </div>
+                </div>
+            </div>`
+        return container
+    }
+
+    mount(container: HTMLElement): void {
+        this.form = container.querySelector('#forgotForm') as HTMLFormElement
+        this.form?.addEventListener('submit', this.handleSubmit)
+    }
+
+    unmount(): void {
+        if (this.form) {
+            this.form.removeEventListener('submit', this.handleSubmit)
+        }
+        document.body.classList.remove('login-page')
+    }
+
+    private handleSubmit = async (e: Event) => {
+        e.preventDefault()
+        if (!this.form) return
+        const button = this.form.querySelector('#forgotButton') as HTMLButtonElement
+        button.disabled = true
+        try {
+            await authService.forgotPassword((this.form.querySelector('#email') as HTMLInputElement).value)
+            window.location.href = '/login'
+        } catch (err: any) {
+            alert(err.message || 'Błąd podczas wysyłania emaila')
+        } finally {
+            button.disabled = false
+        }
+    }
+}

--- a/resources/ts/components/auth/LoginPage.ts
+++ b/resources/ts/components/auth/LoginPage.ts
@@ -1,0 +1,92 @@
+import { authService } from '@services/AuthService'
+import type { RouteComponent } from '@router/routes'
+
+export class LoginPage implements RouteComponent {
+    private form: HTMLFormElement | null = null
+
+    async render(): Promise<HTMLElement> {
+        const container = document.createElement('div')
+        document.body.classList.add('login-page')
+        container.innerHTML = `
+            <div class="login-container">
+                <div class="login-form-section">
+                    <div class="login-logo">Platforma Lektorów</div>
+                    <h1 class="form-title">Witaj ponownie!</h1>
+                    <p class="form-subtitle">Zaloguj się, aby rozpocząć naukę</p>
+                    <form id="loginForm">
+                        <div class="form-group">
+                            <label for="email">Adres e-mail</label>
+                            <input type="email" id="email" name="email" class="form-control" required>
+                            <div class="error-message" id="emailError">Wprowadź poprawny adres e-mail</div>
+                        </div>
+                        <div class="form-group">
+                            <label for="password">Hasło</label>
+                            <input type="password" id="password" name="password" class="form-control" required>
+                            <div class="error-message" id="passwordError">Hasło jest wymagane</div>
+                        </div>
+                        <div class="form-options">
+                            <div class="remember-me">
+                                <input type="checkbox" id="remember" name="remember">
+                                <label for="remember">Zapamiętaj mnie</label>
+                            </div>
+                        </div>
+                        <button type="submit" class="login-btn" id="loginButton">
+                            <span id="buttonText">Zaloguj się</span>
+                            <div class="loading-spinner" id="loadingSpinner"></div>
+                        </button>
+                    </form>
+                </div>
+                <div class="login-info-section">
+                    <div>
+                        <h2>Rozpocznij naukę już dziś!</h2>
+                        <p>Nasza platforma oferuje najlepsze doświadczenie nauki języków obcych online.</p>
+                    </div>
+                </div>
+            </div>
+        `
+        return container
+    }
+
+    mount(container: HTMLElement): void {
+        this.form = container.querySelector('#loginForm') as HTMLFormElement
+        this.form?.addEventListener('submit', this.handleSubmit)
+    }
+
+    unmount(): void {
+        if (this.form) {
+            this.form.removeEventListener('submit', this.handleSubmit)
+        }
+        document.body.classList.remove('login-page')
+    }
+
+    private handleSubmit = async (e: Event) => {
+        e.preventDefault()
+        if (!this.form) return
+        const emailInput = this.form.querySelector('#email') as HTMLInputElement
+        const passwordInput = this.form.querySelector('#password') as HTMLInputElement
+        const rememberInput = this.form.querySelector('#remember') as HTMLInputElement
+        const button = this.form.querySelector('#loginButton') as HTMLButtonElement
+        const spinner = this.form.querySelector('#loadingSpinner') as HTMLElement
+        const buttonText = this.form.querySelector('#buttonText') as HTMLElement
+
+        button.disabled = true
+        spinner.style.display = 'inline-block'
+        buttonText.style.display = 'none'
+
+        try {
+            await authService.login({
+                email: emailInput.value,
+                password: passwordInput.value,
+                remember: rememberInput.checked
+            })
+            window.location.href = '/'
+        } catch (err: any) {
+            const msg = err.message || 'Błąd logowania'
+            alert(msg)
+        } finally {
+            button.disabled = false
+            spinner.style.display = 'none'
+            buttonText.style.display = 'inline'
+        }
+    }
+}

--- a/resources/ts/components/auth/RegisterPage.ts
+++ b/resources/ts/components/auth/RegisterPage.ts
@@ -1,0 +1,80 @@
+import { authService } from '@services/AuthService'
+import type { RouteComponent } from '@router/routes'
+
+export class RegisterPage implements RouteComponent {
+    private form: HTMLFormElement | null = null
+
+    async render(): Promise<HTMLElement> {
+        const container = document.createElement('div')
+        document.body.classList.add('login-page')
+        container.innerHTML = `
+            <div class="login-container">
+                <div class="login-form-section">
+                    <div class="login-logo">Platforma Lektorów</div>
+                    <h1 class="form-title">Rejestracja</h1>
+                    <form id="registerForm">
+                        <div class="form-group">
+                            <label for="name">Imię i nazwisko</label>
+                            <input type="text" id="name" name="name" class="form-control" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="email">Adres e-mail</label>
+                            <input type="email" id="email" name="email" class="form-control" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="password">Hasło</label>
+                            <input type="password" id="password" name="password" class="form-control" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="password_confirmation">Potwierdź hasło</label>
+                            <input type="password" id="password_confirmation" name="password_confirmation" class="form-control" required>
+                        </div>
+                        <button type="submit" class="login-btn" id="registerButton">Załóż konto</button>
+                    </form>
+                </div>
+                <div class="login-info-section">
+                    <div>
+                        <h2>Dołącz do nas!</h2>
+                        <p>Ucz się języków z najlepszymi lektorami online.</p>
+                    </div>
+                </div>
+            </div>`
+        return container
+    }
+
+    mount(container: HTMLElement): void {
+        this.form = container.querySelector('#registerForm') as HTMLFormElement
+        this.form?.addEventListener('submit', this.handleSubmit)
+    }
+
+    unmount(): void {
+        if (this.form) {
+            this.form.removeEventListener('submit', this.handleSubmit)
+        }
+        document.body.classList.remove('login-page')
+    }
+
+    private handleSubmit = async (e: Event) => {
+        e.preventDefault()
+        if (!this.form) return
+        const button = this.form.querySelector('#registerButton') as HTMLButtonElement
+        button.disabled = true
+        try {
+            await authService.register({
+                name: (this.form.querySelector('#name') as HTMLInputElement).value,
+                email: (this.form.querySelector('#email') as HTMLInputElement).value,
+                password: (this.form.querySelector('#password') as HTMLInputElement).value,
+                password_confirmation: (this.form.querySelector('#password_confirmation') as HTMLInputElement).value,
+                role: 'student',
+                phone: '',
+                city: '',
+                terms_accepted: true
+            })
+            window.location.href = '/verify-email'
+        } catch (err: any) {
+            alert(err.message || 'Błąd podczas rejestracji')
+        } finally {
+            button.disabled = false
+        }
+    }
+}

--- a/resources/ts/components/auth/ResetPasswordPage.ts
+++ b/resources/ts/components/auth/ResetPasswordPage.ts
@@ -1,0 +1,70 @@
+import { authService } from '@services/AuthService'
+import type { RouteComponent } from '@router/routes'
+
+export class ResetPasswordPage implements RouteComponent {
+    private form: HTMLFormElement | null = null
+    private token: string = ''
+
+    async render(): Promise<HTMLElement> {
+        const container = document.createElement('div')
+        document.body.classList.add('login-page')
+        const params = new URLSearchParams(window.location.search)
+        this.token = params.get('token') || ''
+        container.innerHTML = `
+            <div class="login-container">
+                <div class="login-form-section">
+                    <div class="login-logo">Platforma Lektorów</div>
+                    <h1 class="form-title">Ustaw nowe hasło</h1>
+                    <form id="resetForm">
+                        <div class="form-group">
+                            <label for="password">Nowe hasło</label>
+                            <input type="password" id="password" name="password" class="form-control" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="password_confirmation">Potwierdź hasło</label>
+                            <input type="password" id="password_confirmation" name="password_confirmation" class="form-control" required>
+                        </div>
+                        <button type="submit" class="login-btn" id="resetButton">Zmień hasło</button>
+                    </form>
+                </div>
+                <div class="login-info-section">
+                    <div>
+                        <h2>Przywracanie dostępu</h2>
+                        <p>Wprowadź nowe hasło do swojego konta.</p>
+                    </div>
+                </div>
+            </div>`
+        return container
+    }
+
+    mount(container: HTMLElement): void {
+        this.form = container.querySelector('#resetForm') as HTMLFormElement
+        this.form?.addEventListener('submit', this.handleSubmit)
+    }
+
+    unmount(): void {
+        if (this.form) {
+            this.form.removeEventListener('submit', this.handleSubmit)
+        }
+        document.body.classList.remove('login-page')
+    }
+
+    private handleSubmit = async (e: Event) => {
+        e.preventDefault()
+        if (!this.form) return
+        const button = this.form.querySelector('#resetButton') as HTMLButtonElement
+        button.disabled = true
+        try {
+            await authService.resetPassword({
+                token: this.token,
+                password: (this.form.querySelector('#password') as HTMLInputElement).value,
+                password_confirmation: (this.form.querySelector('#password_confirmation') as HTMLInputElement).value
+            })
+            window.location.href = '/login'
+        } catch (err: any) {
+            alert(err.message || 'Błąd resetowania hasła')
+        } finally {
+            button.disabled = false
+        }
+    }
+}

--- a/resources/ts/components/common/Footer.ts
+++ b/resources/ts/components/common/Footer.ts
@@ -1,0 +1,29 @@
+
+export class Footer {
+    render(): HTMLElement {
+        const footer = document.createElement('footer')
+        footer.innerHTML = `
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h3>O nas</h3>
+                    <p>Jesteśmy platformą łączącą uczniów z najlepszymi lektorami języków obcych.</p>
+                </div>
+                <div class="footer-section">
+                    <h3>Kontakt</h3>
+                    <p>📧 kontakt@platforma.pl</p>
+                    <p>📞 +48 123 456 789</p>
+                </div>
+                <div class="footer-section">
+                    <h3>Informacje</h3>
+                    <a href="#regulamin">Regulamin</a><br>
+                    <a href="#polityka">Polityka prywatności</a><br>
+                    <a href="#faq">FAQ</a>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 Platforma Lektorów</p>
+            </div>
+        `
+        return footer
+    }
+}

--- a/resources/ts/components/common/Navigation.ts
+++ b/resources/ts/components/common/Navigation.ts
@@ -1,0 +1,19 @@
+
+export class Navigation {
+    render(): HTMLElement {
+        const header = document.createElement('header')
+        header.innerHTML = `
+            <nav class="navbar">
+                <div class="logo">Platforma Lektorów</div>
+                <ul class="nav-links">
+                    <li><a href="/">Start</a></li>
+                    <li><a href="/#lecturers">Lektorzy</a></li>
+                    <li><a href="/#about">O nas</a></li>
+                    <li><a href="/#contact">Kontakt</a></li>
+                </ul>
+                <a href="/login" class="login-btn">Zaloguj się</a>
+            </nav>
+        `
+        return header
+    }
+}

--- a/resources/ts/components/dashboard/AdminDashboard.ts
+++ b/resources/ts/components/dashboard/AdminDashboard.ts
@@ -1,0 +1,10 @@
+import type { RouteComponent } from '@router/routes'
+
+export class AdminDashboard implements RouteComponent {
+    async render(): Promise<HTMLElement> {
+        const el = document.createElement('div')
+        el.className = 'admin-dashboard'
+        el.innerHTML = `<h1>Panel Administratora</h1>`
+        return el
+    }
+}

--- a/resources/ts/components/dashboard/StudentDashboard.ts
+++ b/resources/ts/components/dashboard/StudentDashboard.ts
@@ -1,0 +1,10 @@
+import type { RouteComponent } from '@router/routes'
+
+export class StudentDashboard implements RouteComponent {
+    async render(): Promise<HTMLElement> {
+        const el = document.createElement('div')
+        el.className = 'student-dashboard'
+        el.innerHTML = `<h1>Panel Studenta</h1>`
+        return el
+    }
+}

--- a/resources/ts/components/pages/HomePage.ts
+++ b/resources/ts/components/pages/HomePage.ts
@@ -1,0 +1,94 @@
+import { Navigation } from '../common/Navigation'
+import { Footer } from '../common/Footer'
+import type { RouteComponent } from '@router/routes'
+
+export class HomePage implements RouteComponent {
+    async render(): Promise<HTMLElement> {
+        const container = document.createElement('div')
+        const nav = new Navigation()
+        const footer = new Footer()
+        container.appendChild(nav.render())
+        container.innerHTML += `
+            <section class="hero" id="home">
+                <div class="container">
+                    <h1>Nauka języków online z najlepszymi lektorami</h1>
+                    <p>Personalizowane lekcje, elastyczny harmonogram, sprawdzone metody nauczania</p>
+                    <div class="cta-buttons">
+                        <a href="#lecturers" class="btn btn-primary">Zobacz lektorów</a>
+                        <a href="#about" class="btn btn-secondary">Dowiedz się więcej</a>
+                    </div>
+                </div>
+            </section>
+            <section class="features">
+                <div class="container">
+                    <h2>Dlaczego warto nas wybrać?</h2>
+                    <div class="features-grid">
+                        <div class="feature-card">
+                            <div class="feature-icon">🎯</div>
+                            <h3>Spersonalizowane lekcje</h3>
+                            <p>Każda lekcja dostosowana do Twoich potrzeb i poziomu zaawansowania</p>
+                        </div>
+                        <div class="feature-card">
+                            <div class="feature-icon">⏰</div>
+                            <h3>Elastyczny harmonogram</h3>
+                            <p>Uczysz się kiedy chcesz - dostępność lektorów 7 dni w tygodniu</p>
+                        </div>
+                        <div class="feature-card">
+                            <div class="feature-icon">🌟</div>
+                            <h3>Doświadczeni lektorzy</h3>
+                            <p>Wszystkich naszych lektorów łączy pasja do nauczania i wysokie kwalifikacje</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <section class="lecturers" id="lecturers">
+                <div class="container">
+                    <h2>Poznaj naszych lektorów</h2>
+                    <div class="lecturers-grid">
+                        <div class="lecturer-card">
+                            <div class="lecturer-avatar">👩‍🏫</div>
+                            <div class="lecturer-info">
+                                <div class="lecturer-name">Anna Kowalska</div>
+                                <div class="lecturer-languages">Angielski, Niemiecki</div>
+                                <div class="lecturer-rating">
+                                    <span class="stars">⭐⭐⭐⭐⭐</span>
+                                    <span>5.0 (124 opinii)</span>
+                                </div>
+                                <p>Specjalizuje się w języku biznesowym i przygotowaniu do egzaminów międzynarodowych.</p>
+                            </div>
+                        </div>
+                        <div class="lecturer-card">
+                            <div class="lecturer-avatar">👨‍🏫</div>
+                            <div class="lecturer-info">
+                                <div class="lecturer-name">Piotr Novak</div>
+                                <div class="lecturer-languages">Francuski, Hiszpański</div>
+                                <div class="lecturer-rating">
+                                    <span class="stars">⭐⭐⭐⭐⭐</span>
+                                    <span>4.9 (89 opinii)</span>
+                                </div>
+                                <p>Nativespeaker z długoletnim doświadczeniem w nauczaniu konwersacji.</p>
+                            </div>
+                        </div>
+                        <div class="lecturer-card">
+                            <div class="lecturer-avatar">👩‍🏫</div>
+                            <div class="lecturer-info">
+                                <div class="lecturer-name">Maria Silva</div>
+                                <div class="lecturer-languages">Włoski, Portugalski</div>
+                                <div class="lecturer-rating">
+                                    <span class="stars">⭐⭐⭐⭐⭐</span>
+                                    <span>4.8 (76 opinii)</span>
+                                </div>
+                                <p>Specjalistka w zakresie gramatyki i nauki języków dla dzieci.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="login-note">
+                        <strong>Chcesz zarezerwować lekcję?</strong> Zaloguj się do swojego konta lub skontaktuj się z nami.
+                    </div>
+                </div>
+            </section>
+        `
+        container.appendChild(footer.render())
+        return container
+    }
+}

--- a/resources/ts/components/pages/NotFoundPage.ts
+++ b/resources/ts/components/pages/NotFoundPage.ts
@@ -1,0 +1,12 @@
+import type { RouteComponent } from '@router/routes'
+
+export class NotFoundPage implements RouteComponent {
+    async render(): Promise<HTMLElement> {
+        const el = document.createElement('div')
+        el.className = 'not-found'
+        el.innerHTML = `
+            <h1>404 - Strona nie znaleziona</h1>
+            <p><a href="/">Powrót do strony głównej</a></p>`
+        return el
+    }
+}

--- a/resources/ts/components/pages/UnauthorizedPage.ts
+++ b/resources/ts/components/pages/UnauthorizedPage.ts
@@ -1,0 +1,12 @@
+import type { RouteComponent } from '@router/routes'
+
+export class UnauthorizedPage implements RouteComponent {
+    async render(): Promise<HTMLElement> {
+        const el = document.createElement('div')
+        el.className = 'unauthorized'
+        el.innerHTML = `
+            <h1>Brak uprawnień</h1>
+            <p><a href="/">Powrót do strony głównej</a></p>`
+        return el
+    }
+}


### PR DESCRIPTION
## Summary
- update global CSS imports for all pages
- implement registration and password reset pages with AuthService
- add email verification flow and simple dashboards
- add minimal not-found and unauthorized pages
- clean up unused components

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'vite/client')*
- `composer --version` *(fails: command not found)*
- `./vendor/bin/pint --version` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6850120f87688328a21d45fdf95bbf7d