### PR TITLE
Enable source maps in Vite build configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,5 +32,8 @@ export default defineConfig({
   define: {
     __VUE_OPTIONS_API__: false,
     __VUE_PROD_DEVTOOLS__: false,
+  },
+  build: {
+    sourcemap: true
   }
 })


### PR DESCRIPTION
This change adds the `sourcemap: true` option to the Vite build configuration. It facilitates easier debugging by generating source maps for the built files.