### PR TITLE
Add Contact page with hash routing

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -7,6 +7,7 @@
 
 /* Page styles */
 @import './pages/home.css';
+@import './pages/contact.css';
 @import './pages/login.css';
 @import './pages/register.css';
 @import './pages/forgot-password.css';

--- a/resources/css/pages/contact.css
+++ b/resources/css/pages/contact.css
@@ -1,0 +1,17 @@
+.contact-page {
+    padding: 80px 0;
+}
+.contact-page h1 {
+    text-align: center;
+    margin-bottom: 1rem;
+    color: #1e293b;
+}
+.contact-page p {
+    text-align: center;
+    margin-bottom: 2rem;
+    color: #475569;
+}
+.contact-form {
+    max-width: 600px;
+    margin: 0 auto;
+}

--- a/resources/ts/components/common/Navigation.ts
+++ b/resources/ts/components/common/Navigation.ts
@@ -32,7 +32,7 @@ export class Navigation {
                     <li><a href="/">Start</a></li>
                     <li><a href="/#lecturers">Lektorzy</a></li>
                     <li><a href="/#about">O nas</a></li>
-                    <li><a href="/#contact">Kontakt</a></li>
+                    <li><a href="/#/contact">Kontakt</a></li>
                 </ul>
                 ${navActions}
             </nav>

--- a/resources/ts/components/pages/ContactPage.ts
+++ b/resources/ts/components/pages/ContactPage.ts
@@ -1,0 +1,37 @@
+import { Navigation } from '../common/Navigation'
+import { Footer } from '../common/Footer'
+import type { RouteComponent } from '@router/routes'
+
+export class ContactPage implements RouteComponent {
+    async render(): Promise<HTMLElement> {
+        const container = document.createElement('div')
+        const nav = new Navigation()
+        const footer = new Footer()
+        container.appendChild(nav.render())
+        container.innerHTML += `
+            <section class="contact-page">
+                <div class="container">
+                    <h1>Kontakt</h1>
+                    <p>Masz pytania? Wypełnij formularz lub napisz do nas.</p>
+                    <form id="contactForm" class="contact-form">
+                        <div class="mb-3">
+                            <label for="name" class="form-label">Imię</label>
+                            <input type="text" id="name" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="email" class="form-label">Email</label>
+                            <input type="email" id="email" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="message" class="form-label">Wiadomość</label>
+                            <textarea id="message" class="form-control" rows="5" required></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Wyślij</button>
+                    </form>
+                </div>
+            </section>
+        `
+        container.appendChild(footer.render())
+        return container
+    }
+}

--- a/resources/ts/router/routes.ts
+++ b/resources/ts/router/routes.ts
@@ -60,6 +60,15 @@ export const routes: RouteDefinition[] = [
             layout: 'guest'
         }
     },
+    {
+        path: '/contact',
+        name: 'contact',
+        component: () => import('@/components/pages/ContactPage').then(m => new m.ContactPage()),
+        title: 'Kontakt - Platforma Lektorów',
+        meta: {
+            layout: 'guest'
+        }
+    },
 
     // Auth routes (for guests only - redirect if logged in)
     {

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ Route::get('/reset-password', $spa('/reset-password'))->name('password.reset');
 Route::get('/verify-email', $spa('/verify-email'))->name('verification.notice');
 Route::get('/logout', $spa('/logout'))->name('logout');
 Route::get('/unauthorized', $spa('/unauthorized'))->name('unauthorized');
+Route::get('/contact', $spa('/contact'))->name('contact');
 
 // SPA Route - catch all routes and serve the main app
 Route::get('/{any}', function () {


### PR DESCRIPTION
## Summary
- add Contact page component and style
- include contact route in SPA router and server routes
- add navigation link to new page
- import contact styles

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `composer validate --no-check-publish` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855388a605483289f0730d6d9f38a5d