### PR TITLE
Integrate student CRUD pages

### DIFF
--- a/resources/ts/components/dashboard/AdminDashboard.ts
+++ b/resources/ts/components/dashboard/AdminDashboard.ts
@@ -2,6 +2,7 @@
 import type { RouteComponent } from '@router/routes'
 import { authService } from '@services/AuthService'
 import { api } from '@services/ApiService'
+import { navigateTo } from '@utils/navigation'
 
 export class AdminDashboard implements RouteComponent {
     private activeSection: string = 'dashboard'
@@ -402,7 +403,7 @@ export class AdminDashboard implements RouteComponent {
     }
 
     private navigate(path: string): void {
-        window.location.href = path
+        navigateTo(path)
     }
 
     private showComingSoon(feature: string): void {

--- a/resources/ts/services/StudentService.ts
+++ b/resources/ts/services/StudentService.ts
@@ -87,7 +87,8 @@ export class StudentService {
                 learning_languages: data.learning_languages || [],
                 current_levels: data.current_levels || {},
                 learning_goals: data.learning_goals || [],
-                preferred_schedule: data.preferred_schedule || {}
+                preferred_schedule: data.preferred_schedule || {},
+                status: data.status || 'active'
             })
 
             // Show success notification

--- a/resources/ts/types/models.ts
+++ b/resources/ts/types/models.ts
@@ -41,6 +41,7 @@ export interface CreateStudentRequest {
   current_levels?: Record<string, string>
   learning_goals?: string[]
   preferred_schedule?: Record<string, any>
+  status?: 'active' | 'inactive' | 'blocked'
 }
 
 export interface UpdateStudentRequest {
@@ -54,6 +55,7 @@ export interface UpdateStudentRequest {
   current_levels?: Record<string, string>
   learning_goals?: string[]
   preferred_schedule?: Record<string, any>
+  status?: 'active' | 'inactive' | 'blocked'
 }
 
 export interface StudentFilters {


### PR DESCRIPTION
## Summary
- adapt StudentList, StudentDetails and StudentForm as router components
- use StudentService across student pages and add minimal HTML
- fix StudentList filter key typing
- use navigateTo from admin dashboard
- add search and status controls to student list
- support status field in student form and service

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'vite/client')*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*)

------
https://chatgpt.com/codex/tasks/task_e_686680bafdf08328b0255d5798bedc9d