### PR TITLE
Add admin student management UI

### DIFF
--- a/resources/ts/components/dashboard/AdminDashboard.ts
+++ b/resources/ts/components/dashboard/AdminDashboard.ts
@@ -2,6 +2,7 @@
 import type { RouteComponent } from '@router/routes'
 import { authService } from '@services/AuthService'
 import { api } from '@services/ApiService'
+import { StudentList } from '@components/students/StudentList'
 
 export class AdminDashboard implements RouteComponent {
     private activeSection: string = 'dashboard'
@@ -284,6 +285,7 @@ export class AdminDashboard implements RouteComponent {
             case 'uczniowie':
                 pageTitle.textContent = 'Zarządzanie Uczniami'
                 contentArea.innerHTML = this.getStudentsContent()
+                new StudentList()
                 break
 
             case 'lekcje':
@@ -438,19 +440,40 @@ export class AdminDashboard implements RouteComponent {
     private getStudentsContent(): string {
         return `
             <div class="admin-content-area">
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem;">
+                <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem;">
                     <h2>Lista Uczniów</h2>
-                    <div style="display: flex; gap: 1rem;">
+                    <div style="display:flex;gap:1rem;">
                         <a href="/admin/students/add" class="admin-action-btn">+ Dodaj Ucznia</a>
-                        <a href="/admin/import/students" class="admin-action-btn" style="background: #10b981;">📥 Import CSV</a>
+                        <a href="#" class="admin-action-btn coming-soon">Eksport (wkrótce)</a>
                     </div>
                 </div>
-                <p>Zarządzaj uczniami, ich pakietami godzin i przypisaniami do lektorów.</p>
-                
-                <!-- Tu będzie tabela z uczniami -->
-                <div class="table-container">
-                    <p class="admin-text-muted">Tabela</p>
+
+                <form id="student-filters" class="admin-filters" style="margin-bottom:1rem;display:flex;gap:1rem;">
+                    <input type="text" name="search" placeholder="Szukaj..." />
+                    <select name="status">
+                        <option value="active">Aktywny</option>
+                        <option value="inactive">Nieaktywny</option>
+                        <option value="blocked">Zablokowany</option>
+                    </select>
+                    <button type="submit" class="admin-action-btn">Filtruj</button>
+                    <button type="button" class="admin-action-btn reset-filters">Resetuj</button>
+                </form>
+
+                <div class="table-responsive">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Student</th>
+                                <th>Telefon</th>
+                                <th>Pakiet godzin</th>
+                                <th>Status</th>
+                                <th>Akcje</th>
+                            </tr>
+                        </thead>
+                        <tbody class="student-table"></tbody>
+                    </table>
                 </div>
+                <div class="pagination-container" style="margin-top:1rem;"></div>
             </div>
         `
     }

--- a/resources/ts/components/students/StudentDetails.ts
+++ b/resources/ts/components/students/StudentDetails.ts
@@ -245,6 +245,24 @@ export class StudentDetails {
                     </div>
                 </div>
             </div>
+
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0">Płatności</h5>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted text-center">Moduł płatności będzie dostępny wkrótce.</p>
+                </div>
+            </div>
+
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0">Postępy</h5>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted text-center">Sekcja postępów będzie dostępna w przyszłych wersjach.</p>
+                </div>
+            </div>
         `
     }
 

--- a/resources/ts/services/StudentService.ts
+++ b/resources/ts/services/StudentService.ts
@@ -80,6 +80,7 @@ export class StudentService {
                 name: data.name,
                 email: data.email,
                 password: data.password,
+                status: data.status || 'active',
                 phone: data.phone,
                 birth_date: data.birth_date,
                 city: data.city,

--- a/resources/ts/types/models.ts
+++ b/resources/ts/types/models.ts
@@ -33,6 +33,7 @@ export interface CreateStudentRequest {
   name: string
   email: string
   password?: string
+  status?: 'active' | 'inactive' | 'blocked'
   phone?: string
   birth_date?: string
   city?: string
@@ -50,6 +51,7 @@ export interface UpdateStudentRequest {
   birth_date?: string
   city?: string
   country?: string
+  status?: 'active' | 'inactive' | 'blocked'
   learning_languages?: string[]
   current_levels?: Record<string, string>
   learning_goals?: string[]


### PR DESCRIPTION
## Summary
- integrate `StudentList` in admin dashboard with filters and pagination
- allow status change directly from the list
- add student form component with password confirmation and optional password when editing
- support student status field and new placeholders in student profile
- extend models and service for student status

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for 'vite/client')*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68668c0d89b88328a232cea227a862e7